### PR TITLE
Make the fields in AppVersion public

### DIFF
--- a/Sources/Recap/Public/AppVersion.swift
+++ b/Sources/Recap/Public/AppVersion.swift
@@ -5,8 +5,8 @@ import Foundation
 /// - The `string` will be used as the unique identifier for a `Release`, to only display a release once.
 /// - The `change` property is useful metadata, for example when creating logic to only present a RecapScreen when there is a major or minor change.
 public struct AppVersion: Equatable {
-    let string: String
-    let change: Change
+    public let string: String
+    public let change: Change
 
     public init(string: String, change: Change) {
         self.string = string


### PR DESCRIPTION
This PR makes the fields in `AppVersion` public.

We're writing code to see if our `Releases.md` file actually contains releases for us to display (we don't always update the release notes thing for every release), and this change is required so we can see what versions are present.