### PR TITLE
Fix dismiss button appearance on Mac, fix logic for whether to show tab indicators or not

### DIFF
--- a/Sources/Recap/Public/RecapScreen.swift
+++ b/Sources/Recap/Public/RecapScreen.swift
@@ -82,6 +82,7 @@ public struct RecapScreen<LeadingView: View, TrailingView: View>: View {
                 .contentShape(.rect(cornerRadius: 16.0))
             })
             .frame(maxWidth: .infinity)
+            .buttonStyle(.borderless)
             .background(self.dismissButtonStyle.backgroundStyle)
             .versionSpecificClipShape()
             .padding(.horizontal, 40.0)

--- a/Sources/Recap/Public/RecapScreen.swift
+++ b/Sources/Recap/Public/RecapScreen.swift
@@ -61,7 +61,7 @@ public struct RecapScreen<LeadingView: View, TrailingView: View>: View {
                 self.trailingView
                     .tag(self.tabIndex(from: .trailingView))
             }
-            .tabViewStyle(.page(indexDisplayMode: self.releases.count > 1 ? .always : .never))
+            .tabViewStyle(.page(indexDisplayMode: self.hasMultiplePages ? .always : .never))
             .background(self.derivedBackgroundStyle)
 
             Button(action: {
@@ -133,6 +133,12 @@ public extension RecapScreen where LeadingView == EmptyView, TrailingView == Emp
 private extension RecapScreen {
     var displayedReleases: [Release] {
         self.releases.reversed()
+    }
+
+    var hasMultiplePages: Bool {
+        let hasLeading: Bool = (LeadingView.self != EmptyView.self)
+        let hasTrailing: Bool = (TrailingView.self != EmptyView.self)
+        return hasLeading || hasTrailing || self.releases.count > 1
     }
 
     var derivedBackgroundStyle: AnyShapeStyle {


### PR DESCRIPTION
macOS Tahoe's SwiftUI button appearance (perhaps just in Catalyst apps) has changed to render a border around buttons in the default button style. This PR explicitly adds `.buttonStyle(.borderless)` to the dismiss button to fix this.

iOS already defaults to the borderless button style, so this PR doesn't affect iOS.

This PR **also** shows the tab page indicators if there's a leading or trailing view and only one release. Previously, only the release count was taken into account.

(Sorry this is one PR not two - I forgot how PRs worked for a second there)

Before the changes:

<img width="692" height="752" alt="Screenshot 2025-10-09 at 10 15 56" src="https://github.com/user-attachments/assets/3e901fcf-02a4-4fd9-a34d-aefe597b6e63" />

After the changes:

<img width="692" height="752" alt="Screenshot 2025-10-09 at 10 46 43" src="https://github.com/user-attachments/assets/eb64ada9-f135-4261-b53b-c54816f96c8f" />